### PR TITLE
use correct framework

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net80</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <!-- Make sure start same folder .NET Core CLI and Visual Studio -->
         <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks